### PR TITLE
Allow access to query.builder after parsing common parameters and forbid adding of criteria after building. 

### DIFF
--- a/restler-core/src/main/java/net/researchgate/restdsl/queries/ServiceQuery.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/queries/ServiceQuery.java
@@ -1,7 +1,7 @@
 package net.researchgate.restdsl.queries;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
@@ -32,7 +32,7 @@ public final class ServiceQuery<K> {
     private String order;
     private Set<String> fields;
     private Collection<K> ids;
-    private ImmutableMultimap<String, Object> criteria;
+    private Multimap<String, Object> criteria;
     private boolean indexValidation = true;
     private String groupBy;
     private Boolean countOnly = false;
@@ -72,7 +72,7 @@ public final class ServiceQuery<K> {
         return fields;
     }
 
-    public ImmutableMultimap<String, Object> getCriteria() {
+    public Multimap<String, Object> getCriteria() {
         return criteria;
     }
 
@@ -141,7 +141,6 @@ public final class ServiceQuery<K> {
         }
 
         private ServiceQuery<K> query = new ServiceQuery<>();
-        private Multimap<String, Object> criteria;
 
         public ServiceQueryBuilder<K> offset(Integer offset) throws RestDslException {
             if (offset != null) {
@@ -226,11 +225,11 @@ public final class ServiceQuery<K> {
                 throw new RestDslException("Criteria values for field '" + key + "' cannot be empty",
                         RestDslException.Type.QUERY_ERROR);
             }
-            if (criteria == null) {
-                criteria = LinkedHashMultimap.create();
+            if (query.criteria == null) {
+                query.criteria = HashMultimap.create();
             }
 
-            criteria.putAll(key, value);
+            query.criteria.putAll(key, value);
             return this;
         }
 
@@ -246,7 +245,6 @@ public final class ServiceQuery<K> {
 
         public ServiceQuery<K> build() {
             applyServiceQueryParams();
-            query.criteria = ImmutableMultimap.copyOf(this.criteria);
             query.calculateQueryShape();
             return query;
         }
@@ -255,9 +253,7 @@ public final class ServiceQuery<K> {
             // CRITERIA
             Multimap<String, Object> defaultCriteria = serviceQueryParams.getDefaultCriteria();
             if (defaultCriteria != null && !defaultCriteria.isEmpty()) {
-                Multimap<String, Object> combinedCriteria = criteria != null
-                        ? LinkedHashMultimap.create(criteria)
-                        : LinkedHashMultimap.create();
+                Multimap<String, Object> combinedCriteria = query.criteria != null ? LinkedHashMultimap.create(query.criteria) : LinkedHashMultimap.create();
                 // Merge defaultCriteria and user defined criteria
                 for (String key : defaultCriteria.keys()) {
                     if (!combinedCriteria.containsKey(key)) {
@@ -269,7 +265,7 @@ public final class ServiceQuery<K> {
                         .filter(key -> combinedCriteria.get(key).size() == 1 &&
                                 combinedCriteria.get(key).contains(ServiceQueryReservedValue.ANY)
                         ).forEach(combinedCriteria::removeAll);
-                criteria = combinedCriteria;
+                query.criteria = combinedCriteria;
             }
 
             // FIELDS

--- a/restler-core/src/main/java/net/researchgate/restdsl/resources/ServiceResource.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/resources/ServiceResource.java
@@ -121,7 +121,12 @@ public abstract class ServiceResource<V, K> {
 
 
     protected ServiceQuery<K> getQueryFromRequest(PathSegment segment, UriInfo uriInfo) throws RestDslException {
-        return RequestUtil.parseRequest(entityClazz, idClazz, segment, uriInfo, getServiceQueryParams());
+        return RequestUtil.parseCommonParameters(entityClazz, idClazz, segment, uriInfo, getServiceQueryParams())
+                .build();
+    }
+
+    protected ServiceQuery.ServiceQueryBuilder<K> getBuilderFromRequest(PathSegment segment, UriInfo uriInfo) throws RestDslException {
+        return RequestUtil.parseCommonParameters(entityClazz, idClazz, segment, uriInfo, getServiceQueryParams());
     }
 
     protected void validatePostEntity(V entity) throws RestDslException {

--- a/restler-core/src/main/java/net/researchgate/restdsl/util/RequestUtil.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/util/RequestUtil.java
@@ -78,6 +78,15 @@ public class RequestUtil {
     }
 
     public static <K, V> ServiceQuery<K> parseRequest(Class<V> entityClazz, Class<K> idClazz, PathSegment segment, UriInfo uriInfo, ServiceQueryParams serviceQueryParams) throws RestDslException {
+        return parseCommonParameters(entityClazz, idClazz, segment, uriInfo, serviceQueryParams)
+                .build();
+    }
+
+    public static <K, V> ServiceQuery.ServiceQueryBuilder<K> parseCommonParameters(Class<V> entityClazz,
+                                                                                    Class<K> idClazz,
+                                                                                    PathSegment segment,
+                                                                                    UriInfo uriInfo,
+                                                                                    ServiceQueryParams serviceQueryParams) {
         ServiceQuery.ServiceQueryBuilder<K> builder = ServiceQuery.builder();
 
         builder.offset(getInt("offset", uriInfo));
@@ -117,8 +126,7 @@ public class RequestUtil {
             builder.ids(Lists.transform(Splitter.on(',').splitToList(segment.getPath()),
                     input -> TypeInfoUtil.getValue(input, EntityInfo.get(entityClazz).getIdFieldName(), idClazz, entityClazz)));
         }
-
-        return builder.build();
+        return builder;
     }
 
 }


### PR DESCRIPTION
note that criteria is still not fully immutable due to mutable values.