### PR TITLE
fix ServiceQuery withCriteria to satisfy PECS

### DIFF
--- a/restler-core/src/main/java/net/researchgate/restdsl/queries/ServiceQuery.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/queries/ServiceQuery.java
@@ -220,7 +220,7 @@ public final class ServiceQuery<K> {
             return withCriteria(key, Collections.singletonList(value));
         }
 
-        public ServiceQueryBuilder<K> withCriteria(String key, Collection<Object> value) throws RestDslException {
+        public ServiceQueryBuilder<K> withCriteria(String key, Collection<?> value) throws RestDslException {
             if (value == null || value.isEmpty()) {
                 throw new RestDslException("Criteria values for field '" + key + "' cannot be empty",
                         RestDslException.Type.QUERY_ERROR);


### PR DESCRIPTION
Current implementation does not allow to pass a `Collection<String>` even though Mongo supports it well. This patch makes it work, and makes it satisfy PECS https://stackoverflow.com/questions/2723397/what-is-pecs-producer-extends-consumer-super