### PR TITLE
Always add ; separator in Info query

### DIFF
--- a/restler-core/src/main/java/net/researchgate/restdsl/queries/ServiceQuery.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/queries/ServiceQuery.java
@@ -289,8 +289,9 @@ public final class ServiceQuery<K> {
         if (ids != null && !ids.isEmpty()) {
             sb.append(Joiner.on(",").join(ids));
         } else {
-            sb.append("-;");
+            sb.append("-");
         }
+        sb.append(';');
         if (criteria != null) {
             for (String c : criteria.keySet()) {
                 sb.append(c).append("=");


### PR DESCRIPTION
Always insert ;-separator between ID-part and criteria-part for info query URL part.

Fixes #8