### PR TITLE
Change oraclejdk8 by openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
The install of oraclejdk8 is failling. The fix as stated here https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365 is to either change the dist or change to openjdk. I think the proper solution is to use openjdk