### PR TITLE
Cargo 2356: Split into full CRUD and convenience read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Typical `$query_params`:
 * `offset (Integer)` - how many records to skip
 * `order (String)` - order by a certain field
 * `fields (String)` - comma-separated list of fields to return 
-* `groupBy (String)` - group by a certain field
+* `groupBy (String)` - group by a certain field. Starting from version 3.1.0, groupBy can be forbidden by the dao, in order to prevent too much load on the database. 
 * `indexValidation (boolean)` - whether enable index validation in your DAO (`true` by default)
 
 Examples:

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ project(":restler-core") {
 
         runtime group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.7'
 
+        testImplementation 'com.github.fakemongo:fongo:2.1.0'
         testCompile group: 'junit', name: 'junit', version: '4.11'
         testCompile group: 'org.mockito', name: 'mockito-all', version: '1.+'
         testCompile group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.23.1'

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,0 +1,6 @@
+# Changelog
+
+### 3.1.0
+ * Backwards incompatible change: The BaseServiceResource now uses a BaseServiceModel (was: ServiceModel), with a smaller api. If you need the api of the ServiceModel, you can keep a reference to the passed in ServiceModel to the constructor. 
+ * Feature: Split out BaseServiceModel and BaseServiceDao that expose just the read restDsl 
+ * Feature: It is now possible to prevent client from performing groupBy queries. 

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseMongoServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseMongoServiceDao.java
@@ -1,0 +1,348 @@
+package net.researchgate.restdsl.dao;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import net.researchgate.restdsl.domain.EntityIndexInfo;
+import net.researchgate.restdsl.domain.EntityInfo;
+import net.researchgate.restdsl.exceptions.RestDslException;
+import net.researchgate.restdsl.metrics.NoOpStatsReporter;
+import net.researchgate.restdsl.metrics.StatsReporter;
+import net.researchgate.restdsl.metrics.StatsTimingWrapper;
+import net.researchgate.restdsl.queries.ServiceQuery;
+import net.researchgate.restdsl.queries.ServiceQueryInfo;
+import net.researchgate.restdsl.queries.ServiceQueryReservedValue;
+import net.researchgate.restdsl.results.EntityList;
+import net.researchgate.restdsl.results.EntityMultimap;
+import net.researchgate.restdsl.results.EntityResult;
+import net.researchgate.restdsl.types.TypeInfoUtil;
+import net.researchgate.restdsl.util.ServiceQueryUtil;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.dao.BasicDAO;
+import org.mongodb.morphia.query.Query;
+import org.mongodb.morphia.query.UpdateOperations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This Dao implements read only access to the underlying mongo collection.
+ * Use this dao if you want to make sure that your data is only written to in a controlled way.
+ *
+ * If you want to simply expose CRUD via REST, use a {@link MongoServiceDao}.
+ *
+ * @param <V> Type of the entity
+ * @param <K> Type of the entity's id field
+ */
+public class BaseMongoServiceDao<V, K> implements ServiceDao<V, K>{
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseMongoServiceDao.class);
+
+    private static final String QUERY_KEY = "queries.shapes.%s.%%H";
+    protected final String collectionName;
+    protected final BasicDAO<V, K> morphiaDao;
+    protected final Class<V> entityClazz;
+    protected final EntityInfo<V> entityInfo;
+    protected final EntityIndexInfo<V> entityIndexInfo;
+    protected final StatsReporter statsReporter;
+
+    // group by operations may require a lot requests to the database. We should have to explicitly enable it
+    protected boolean allowGroupBy = false;
+
+    public BaseMongoServiceDao(Datastore datastore, Class<V> entityClazz) {
+        this(datastore, entityClazz, NoOpStatsReporter.INSTANCE);
+    }
+    //TODO: provide implementations for StatsReporter in example service
+    public BaseMongoServiceDao(Datastore datastore, Class<V> entityClazz, StatsReporter statsReporter) {
+        this.morphiaDao = new BasicDAO<>(entityClazz, datastore);
+        this.collectionName = morphiaDao.getCollection().getName();
+        this.entityClazz = entityClazz;
+        this.entityInfo = EntityInfo.get(entityClazz);
+        this.entityIndexInfo = new EntityIndexInfo<>(entityClazz, morphiaDao.getCollection().getIndexInfo());
+        this.statsReporter = statsReporter;
+    }
+
+    /**
+     * explicitly allow groupBy in get queries.
+     *
+     * If not, we will throw a RestDsl exception when the client queries with a groupBy.
+     */
+    protected void setAllowGroupBy() {
+        this.allowGroupBy = true;
+    }
+
+    public EntityResult<V> get(ServiceQuery<K> serviceQuery) throws RestDslException {
+        Query<V> morphiaQuery = convertToMorphiaQuery(serviceQuery);
+
+        LOGGER.debug("Executing query {}", morphiaQuery);
+
+        try (StatsTimingWrapper ignored = getQueryShapeWrapper(serviceQuery)) {
+            String groupBy = serviceQuery.getGroupBy();
+            if (groupBy == null) {
+                List<V> results = Collections.emptyList();
+                if (!serviceQuery.getCountOnly()) {
+                    results = morphiaDao.find(morphiaQuery).asList();
+                }
+                return new EntityResult<>(results, getTotalItemsCnt(morphiaQuery, serviceQuery, results));
+            } else {
+                if (!allowGroupBy) {
+                    throw new RestDslException("GroupBy is not allowed by this dao, but rquest contains groupBy '" + groupBy + "'. GroupBy can be enabled in the Service", RestDslException.Type.QUERY_ERROR);
+                }
+                // warning: in-place criteria editing
+                Collection<Object> criteriaForGrouping = Lists.newArrayList(serviceQuery.getCriteria().get(groupBy));
+
+                Map<Object, EntityList<V>> groupedResult = new HashMap<>();
+                for (Object k : criteriaForGrouping) {
+                    serviceQuery.getCriteria().removeAll(groupBy);
+                    serviceQuery.getCriteria().put(groupBy, k);
+                    Query<V> q = convertToMorphiaQuery(serviceQuery);
+                    List<V> resultPerKey = Collections.emptyList();
+                    if (!serviceQuery.getCountOnly()) {
+                        resultPerKey = morphiaDao.find(q).asList();
+                    }
+
+                    EntityList<V> entityList = new EntityList<>(resultPerKey, getTotalItemsCnt(q, serviceQuery, resultPerKey));
+                    groupedResult.put(k, entityList);
+                }
+                return new EntityResult<>(new EntityMultimap<>(groupedResult, serviceQuery.isCountTotalItems() ? morphiaQuery.count() : null));
+            }
+        }
+    }
+
+    public V getOne(ServiceQuery<K> serviceQuery) throws RestDslException {
+        return morphiaDao.findOne(convertToMorphiaQuery(serviceQuery));
+    }
+
+    public long count(ServiceQuery<K> serviceQuery) throws RestDslException {
+        return convertToMorphiaQuery(serviceQuery).count();
+    }
+
+    protected UpdateOperations<V> createUpdateOperations() {
+        return morphiaDao.createUpdateOperations();
+    }
+
+    protected Query<V> convertToMorphiaQuery(ServiceQuery<K> serviceQuery) throws RestDslException {
+        return convertToMorphiaQuery(serviceQuery, true);
+    }
+
+    protected Query<V> convertToMorphiaQuery(ServiceQuery<K> serviceQuery, boolean getQuery) throws RestDslException {
+        validateQuery(serviceQuery);
+
+        Query<V> mongoQuery = morphiaDao.createQuery();
+
+        Collection<K> ids = serviceQuery.getIdList();
+        if (ids != null) {
+            if (ids.size() == 1) {
+                mongoQuery.field(entityInfo.getIdFieldName()).equal(ids.iterator().next());
+            } else {
+                mongoQuery.field(entityInfo.getIdFieldName()).hasAnyOf(ids);
+            }
+        }
+
+        if (getQuery) {
+            if (serviceQuery.getFields() != null) {
+                Set<String> excludedFields = Sets.newHashSet();
+                Set<String> includedFields = Sets.newHashSet();
+                boolean all = false;
+                for (String f : serviceQuery.getFields()) {
+                    if (f.equals("*")) {
+                        all = true;
+                    } else {
+                        if (f.startsWith("-")) {
+                            excludedFields.add(f.substring(1));
+                        } else {
+                            includedFields.add(f);
+                        }
+                    }
+                }
+
+                if (!excludedFields.isEmpty() && !includedFields.isEmpty()) {
+                    throw new RestDslException("Query cannot have both included and excluded fields", RestDslException.Type.QUERY_ERROR);
+                }
+
+                if (!all) {
+                    if (!includedFields.isEmpty()) {
+                        includedFields.forEach(f -> mongoQuery.project(f, true));
+                    } else {
+                        // only excluded fields were provided
+                        excludedFields.forEach(f -> mongoQuery.project(f, false));
+                    }
+                } else {
+                    // provided * but also excluded fields
+                    if (!excludedFields.isEmpty()) {
+                        excludedFields.forEach(f -> mongoQuery.project(f, false));
+                    }
+                }
+            }
+
+            mongoQuery.offset(serviceQuery.getOffset());
+            mongoQuery.limit(serviceQuery.getLimit());
+
+            if (serviceQuery.getOrder() != null) {
+                mongoQuery.order(serviceQuery.getOrder());
+            }
+        }
+
+
+        if (serviceQuery.getCriteria() != null) {
+            Multimap<String, String> syncMatchToCriteriaKeys = HashMultimap.create();
+            Set<String> syncMatch = serviceQuery.getSyncMatch() == null ? Collections.emptySet() : serviceQuery.getSyncMatch();
+
+            for (String k : serviceQuery.getCriteria().keySet()) {
+                boolean forSyncMatch = false;
+                for (String sm : syncMatch) {
+                    if (k.startsWith(sm + ".")) {
+                        syncMatchToCriteriaKeys.put(sm, k);
+                        forSyncMatch = true;
+                    }
+                }
+
+                if (forSyncMatch) {
+                    continue;
+                }
+
+                Collection<Object> objs = serviceQuery.getCriteria().get(k);
+                enrichQuery(mongoQuery, k, objs);
+            }
+
+            if (!syncMatchToCriteriaKeys.isEmpty()) {
+                for (String k : syncMatchToCriteriaKeys.keySet()) {
+                    Collection<String> criteriaKeys = syncMatchToCriteriaKeys.get(k);
+
+                    Pair<Class<?>, Class<?>> fieldExpressionClazz = TypeInfoUtil.getFieldExpressionClazz(entityClazz, k);
+                    Query<?> subFieldQuery = morphiaDao.getDatastore().createQuery(fieldExpressionClazz.getLeft());
+                    for (String criteriaKey : criteriaKeys) {
+                        enrichQuery(subFieldQuery, criteriaKey.substring(k.length() + 1), serviceQuery.getCriteria().get(criteriaKey));
+                    }
+
+                    mongoQuery.field(k).elemMatch(subFieldQuery);
+                }
+            }
+        }
+
+        return mongoQuery;
+    }
+
+    private void enrichQuery(Query<?> mongoQuery, String field, Collection<Object> criteria) {
+        if (criteria.size() == 1) {
+            // range query
+            Object val = criteria.iterator().next();
+            // TODO: rather operatte on ParsedField and have a method to determine whether it's some operation
+            if (field.contains(">") || field.contains("<")) {
+                mongoQuery.filter(field, val);
+            } else if (val instanceof ServiceQueryReservedValue) {
+                adaptToReservedValue(mongoQuery, field, (ServiceQueryReservedValue) val);
+            } else {
+                mongoQuery.field(field).equal(val);
+            }
+        } else {
+            // TODO: deal nicely with other operations
+            if (field.contains("<>")) {
+                mongoQuery.field(ServiceQueryUtil.parseQueryField(field).getFieldName()).notIn(criteria);
+            } else {
+                mongoQuery.field(field).in(criteria);
+            }
+        }
+    }
+
+    // optimization. If the returned set is smaller than limit, that means we can calculate size without countAll()
+    private Long getTotalItemsCnt(Query<V> q, ServiceQuery<?> serviceQuery, List<V> results) {
+        if (!serviceQuery.isCountTotalItems()) {
+            return null;
+        }
+
+        if (results.size() > q.getLimit()) {
+            throw new RestDslException("Implementation error: results size must be not greater than limit, was " +
+                    results.size() + " but limit was: " + q.getLimit());
+        }
+
+        if (serviceQuery.getCountOnly()) {
+            return q.count();
+        }
+
+        // if getLimit == 0 then we need to count anyway
+        if (results.size() == 0 && q.getOffset() == 0 && q.getLimit() > 0) {
+            return 0L;
+        }
+
+        // if size is equal 0 it could be that offset is too big, or we just have 0 elements in total - must count
+        if (results.size() != 0 && results.size() < q.getLimit()) {
+            return (long) (q.getOffset() + results.size());
+        } else {
+            return q.count();
+        }
+    }
+
+    private void adaptToReservedValue(Query<?> mongoQuery, String k, ServiceQueryReservedValue val) {
+        if (val == ServiceQueryReservedValue.EXISTS) {
+            mongoQuery.criteria(k).exists();
+        } else if (val == ServiceQueryReservedValue.NULL) {
+            mongoQuery.field(k).equal(null);
+        } else if (val == ServiceQueryReservedValue.ANY) {
+            // no op
+        } else {
+            throw new RestDslException("Unhandled reserved value: " + val, RestDslException.Type.GENERAL_ERROR);
+        }
+    }
+
+    public void validateQuery(ServiceQuery<K> serviceQuery) throws RestDslException {
+        if (serviceQuery.isIndexValidation()) {
+            boolean safeQuery = isSafeQuery(serviceQuery);
+            if (!safeQuery) {
+                throw new RestDslException("Query criterion for fields " + serviceQuery.getCriteria().keySet() +
+                        " don't match declared indexes  [(" + Joiner.on("), (").join(entityIndexInfo.getIndexesMap()) +
+                        ")] for class " + entityClazz.getName() +
+                        "; use '?indexValidation=false' query parameter to temporarily disable it for debugging purposes.",
+                        RestDslException.Type.QUERY_ERROR);
+            }
+        }
+
+        if (serviceQuery.getLimit() < 0) {
+            throw new RestDslException("Query limit must be positive", RestDslException.Type.QUERY_ERROR);
+        }
+
+        // for primary keys it could also works, but it does not make sense to group on them since they are unique
+        if (serviceQuery.getGroupBy() != null &&
+                (serviceQuery.getCriteria() == null || !serviceQuery.getCriteria().containsKey(serviceQuery.getGroupBy()))) {
+            throw new RestDslException("When provided, groupBy parameter should be contained in query criteria",
+                    RestDslException.Type.QUERY_ERROR);
+        }
+
+    }
+
+    public ServiceQueryInfo<K> getServiceQueryInfo(ServiceQuery<K> serviceQuery) {
+        return new ServiceQueryInfo<>(serviceQuery, isSafeQuery(serviceQuery));
+    }
+
+    private boolean isSafeQuery(ServiceQuery<K> serviceQuery) {
+        boolean queryIsSafe = true;
+        // criteria is not empty and primary keys are not specified, then we need to check whether index is used
+        boolean shouldCheckForIndex = serviceQuery.getCriteria() != null && !serviceQuery.getCriteria().isEmpty()
+                && CollectionUtils.isEmpty(serviceQuery.getIdList());
+
+        if (shouldCheckForIndex) {
+            queryIsSafe = false;
+            for (String field : serviceQuery.getCriteria().keySet()) {
+                if (entityIndexInfo.getIndexPrefixMap().contains(ServiceQueryUtil.parseQueryField(field).getFieldName())) {
+                    queryIsSafe = true;
+                    break;
+                }
+            }
+        }
+        return queryIsSafe;
+    }
+
+    // PRIVATE
+    private StatsTimingWrapper getQueryShapeWrapper(ServiceQuery<K> serviceQuery) {
+        return StatsTimingWrapper.of(statsReporter, String.format(QUERY_KEY, collectionName + "." + serviceQuery.getQueryShape()));
+    }
+}

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/MongoServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/MongoServiceDao.java
@@ -1,27 +1,11 @@
 package net.researchgate.restdsl.dao;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 import com.mongodb.DuplicateKeyException;
-import net.researchgate.restdsl.domain.EntityIndexInfo;
-import net.researchgate.restdsl.domain.EntityInfo;
 import net.researchgate.restdsl.exceptions.RestDslException;
 import net.researchgate.restdsl.metrics.NoOpStatsReporter;
 import net.researchgate.restdsl.metrics.StatsReporter;
-import net.researchgate.restdsl.metrics.StatsTimingWrapper;
 import net.researchgate.restdsl.queries.ServiceQuery;
-import net.researchgate.restdsl.queries.ServiceQueryInfo;
-import net.researchgate.restdsl.queries.ServiceQueryReservedValue;
-import net.researchgate.restdsl.results.EntityList;
-import net.researchgate.restdsl.results.EntityMultimap;
-import net.researchgate.restdsl.results.EntityResult;
-import net.researchgate.restdsl.types.TypeInfoUtil;
-import net.researchgate.restdsl.util.ServiceQueryUtil;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.FindAndModifyOptions;
 import org.mongodb.morphia.dao.BasicDAO;
@@ -31,88 +15,37 @@ import org.mongodb.morphia.query.UpdateResults;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
+/**
+ * This dao exposes full CRUD.
+ * Use this if you want simply want to expose the mongo operations via REST.
+ * If you have more challenging businessLogic, consider using a {@link BaseMongoServiceDao} and implement
+ * write operations yourself.
+ *
+ * @param <V> Type of the entity
+ * @param <K> Type of the entity's id field
+ */
 @SuppressWarnings("WeakerAccess")
-public class MongoServiceDao<V, K> implements PersistentServiceDao<V, K> {
+public class MongoServiceDao<V, K> extends BaseMongoServiceDao<V, K> implements PersistentServiceDao<V, K> {
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoServiceDao.class);
-
-    private static final String QUERY_KEY = "queries.shapes.%s.%%H";
-    private final String collectionName;
-
-    private BasicDAO<V, K> morphiaDao;
-    private Class<V> entityClazz;
-    private EntityInfo<V> entityInfo;
-    private EntityIndexInfo<V> entityIndexInfo;
-
-    private StatsReporter statsReporter;
-
-    //TODO: provide implementations for StatsReporter in example service
-
 
     public MongoServiceDao(Datastore datastore, Class<V> entityClazz) {
         this(datastore, entityClazz, NoOpStatsReporter.INSTANCE);
     }
 
     public MongoServiceDao(Datastore datastore, Class<V> entityClazz, StatsReporter statsReporter) {
-        this.morphiaDao = new BasicDAO<>(entityClazz, datastore);
-        this.entityClazz = entityClazz;
-        this.entityInfo = EntityInfo.get(entityClazz);
-        this.entityIndexInfo = new EntityIndexInfo<>(entityClazz, morphiaDao.getCollection().getIndexInfo());
-        this.collectionName = morphiaDao.getCollection().getName();
-        this.statsReporter = statsReporter;
+        // allow group by in order to be backwards compatible.
+        this(datastore, entityClazz, statsReporter, true);
     }
 
-    @Override
-    public EntityResult<V> get(ServiceQuery<K> serviceQuery) throws RestDslException {
-        Query<V> morphiaQuery = convertToMorphiaQuery(serviceQuery);
-
-        LOGGER.debug("Executing query {}", morphiaQuery);
-
-        String groupBy = serviceQuery.getGroupBy();
-        try (StatsTimingWrapper ignored = getQueryShapeWrapper(serviceQuery)) {
-            if (groupBy == null) {
-                List<V> results = Collections.emptyList();
-                if (!serviceQuery.getCountOnly()) {
-                    results = morphiaDao.find(morphiaQuery).asList();
-                }
-                return new EntityResult<>(results, getTotalItemsCnt(morphiaQuery, serviceQuery, results));
-            } else {
-                // warning: in-place criteria editing
-                Collection<Object> criteriaForGrouping = Lists.newArrayList(serviceQuery.getCriteria().get(groupBy));
-
-                Map<Object, EntityList<V>> groupedResult = new HashMap<>();
-                for (Object k : criteriaForGrouping) {
-                    serviceQuery.getCriteria().removeAll(groupBy);
-                    serviceQuery.getCriteria().put(groupBy, k);
-                    Query<V> q = convertToMorphiaQuery(serviceQuery);
-                    List<V> resultPerKey = Collections.emptyList();
-                    if (!serviceQuery.getCountOnly()) {
-                        resultPerKey = morphiaDao.find(q).asList();
-                    }
-
-                    EntityList<V> entityList = new EntityList<>(resultPerKey, getTotalItemsCnt(q, serviceQuery, resultPerKey));
-                    groupedResult.put(k, entityList);
-                }
-                return new EntityResult<>(new EntityMultimap<>(groupedResult, serviceQuery.isCountTotalItems() ? morphiaQuery.count() : null));
-            }
+    // This constructor allows clients to migrate to a dao that does not allow groupBy queries
+    public MongoServiceDao(Datastore datastore, Class<V> entityClazz, StatsReporter statsReporter, boolean allowGroupBy) {
+        super(datastore, entityClazz, statsReporter);
+        // allow group by in order to be backwards compatible.
+        if (allowGroupBy) {
+            setAllowGroupBy();
         }
-    }
-
-
-    @Override
-    public V getOne(ServiceQuery<K> serviceQuery) throws RestDslException {
-        return morphiaDao.findOne(convertToMorphiaQuery(serviceQuery));
-    }
-
-    @Override
-    public long count(ServiceQuery<K> serviceQuery) throws RestDslException {
-        return convertToMorphiaQuery(serviceQuery).count();
     }
 
     @Override
@@ -152,10 +85,6 @@ public class MongoServiceDao<V, K> implements PersistentServiceDao<V, K> {
         return findAndModify(q, ops);
     }
 
-    protected UpdateOperations<V> createUpdateOperations() {
-        return morphiaDao.createUpdateOperations();
-    }
-
     protected UpdateResults update(ServiceQuery<K> q, UpdateOperations<V> updateOperations) throws RestDslException {
         preUpdate(q, updateOperations);
         return morphiaDao.update(convertToMorphiaQuery(q, false), updateOperations);
@@ -188,224 +117,11 @@ public class MongoServiceDao<V, K> implements PersistentServiceDao<V, K> {
         }
     }
 
-    protected Query<V> convertToMorphiaQuery(ServiceQuery<K> serviceQuery) throws RestDslException {
-        return convertToMorphiaQuery(serviceQuery, true);
-    }
-
-    protected Query<V> convertToMorphiaQuery(ServiceQuery<K> serviceQuery, boolean getQuery) throws RestDslException {
-        validateQuery(serviceQuery);
-
-        Query<V> mongoQuery = morphiaDao.createQuery();
-
-        Collection<K> ids = serviceQuery.getIdList();
-        if (ids != null) {
-            if (ids.size() == 1) {
-                mongoQuery.field(entityInfo.getIdFieldName()).equal(ids.iterator().next());
-            } else {
-                mongoQuery.field(entityInfo.getIdFieldName()).hasAnyOf(ids);
-            }
-        }
-
-        if (getQuery) {
-            if (serviceQuery.getFields() != null) {
-                Set<String> excludedFields = Sets.newHashSet();
-                Set<String> includedFields = Sets.newHashSet();
-                boolean all = false;
-                for (String f : serviceQuery.getFields()) {
-                    if (f.equals("*")) {
-                        all = true;
-                    } else {
-                        if (f.startsWith("-")) {
-                            excludedFields.add(f.substring(1));
-                        } else {
-                            includedFields.add(f);
-                        }
-                    }
-                }
-
-                if (!excludedFields.isEmpty() && !includedFields.isEmpty()) {
-                    throw new RestDslException("Query cannot have both included and excluded fields", RestDslException.Type.QUERY_ERROR);
-                }
-
-                if (!all) {
-                    if (!includedFields.isEmpty()) {
-                        includedFields.forEach(f -> mongoQuery.project(f, true));
-                    } else {
-                        // only excluded fields were provided
-                        excludedFields.forEach(f -> mongoQuery.project(f, false));
-                    }
-                } else {
-                    // provided * but also excluded fields
-                    if (!excludedFields.isEmpty()) {
-                        excludedFields.forEach(f -> mongoQuery.project(f, false));
-                    }
-                }
-            }
-
-            mongoQuery.offset(serviceQuery.getOffset());
-            mongoQuery.limit(serviceQuery.getLimit());
-
-            if (serviceQuery.getOrder() != null) {
-                mongoQuery.order(serviceQuery.getOrder());
-            }
-        }
-
-
-        if (serviceQuery.getCriteria() != null) {
-            Multimap<String, String> syncMatchToCriteriaKeys = HashMultimap.create();
-            Set<String> syncMatch = serviceQuery.getSyncMatch() == null ? Collections.emptySet() : serviceQuery.getSyncMatch();
-
-            for (String k : serviceQuery.getCriteria().keySet()) {
-                boolean forSyncMatch = false;
-                for (String sm : syncMatch) {
-                    if (k.startsWith(sm + ".")) {
-                        syncMatchToCriteriaKeys.put(sm, k);
-                        forSyncMatch = true;
-                    }
-                }
-
-                if (forSyncMatch) {
-                    continue;
-                }
-
-                Collection<Object> objs = serviceQuery.getCriteria().get(k);
-                enrichQuery(mongoQuery, k, objs);
-            }
-
-            if (!syncMatchToCriteriaKeys.isEmpty()) {
-                for (String k : syncMatchToCriteriaKeys.keySet()) {
-                    Collection<String> criteriaKeys = syncMatchToCriteriaKeys.get(k);
-
-                    Pair<Class<?>, Class<?>> fieldExpressionClazz = TypeInfoUtil.getFieldExpressionClazz(entityClazz, k);
-                    Query<?> subFieldQuery = morphiaDao.getDatastore().createQuery(fieldExpressionClazz.getLeft());
-                    for (String criteriaKey : criteriaKeys) {
-                        enrichQuery(subFieldQuery, criteriaKey.substring(k.length() + 1), serviceQuery.getCriteria().get(criteriaKey));
-                    }
-
-                    mongoQuery.field(k).elemMatch(subFieldQuery);
-                }
-            }
-        }
-
-        return mongoQuery;
-    }
-
-    private void enrichQuery(Query<?> mongoQuery, String field, Collection<Object> criteria) {
-        if (criteria.size() == 1) {
-            // range query
-            Object val = criteria.iterator().next();
-            // TODO: rather operatte on ParsedField and have a method to determine whether it's some operation
-            if (field.contains(">") || field.contains("<")) {
-                mongoQuery.filter(field, val);
-            } else if (val instanceof ServiceQueryReservedValue) {
-                adaptToReservedValue(mongoQuery, field, (ServiceQueryReservedValue) val);
-            } else {
-                mongoQuery.field(field).equal(val);
-            }
-        } else {
-            // TODO: deal nicely with other operations
-            if (field.contains("<>")) {
-                mongoQuery.field(ServiceQueryUtil.parseQueryField(field).getFieldName()).notIn(criteria);
-            } else {
-                mongoQuery.field(field).in(criteria);
-            }
-        }
-    }
-
-    // optimization. If the returned set is smaller than limit, that means we can calculate size without countAll()
-    private Long getTotalItemsCnt(Query<V> q, ServiceQuery<?> serviceQuery, List<V> results) {
-        if (!serviceQuery.isCountTotalItems()) {
-            return null;
-        }
-
-        if (results.size() > q.getLimit()) {
-            throw new RestDslException("Implementation error: results size must be not greater than limit, was " +
-                    results.size() + " but limit was: " + q.getLimit());
-        }
-
-        if (serviceQuery.getCountOnly()) {
-            return q.count();
-        }
-
-        // if getLimit == 0 then we need to count anyway
-        if (results.size() == 0 && q.getOffset() == 0 && q.getLimit() > 0) {
-            return 0L;
-        }
-
-        // if size is equal 0 it could be that offset is too big, or we just have 0 elements in total - must count
-        if (results.size() != 0 && results.size() < q.getLimit()) {
-            return (long) (q.getOffset() + results.size());
-        } else {
-            return q.count();
-        }
-    }
-
-    private void adaptToReservedValue(Query<?> mongoQuery, String k, ServiceQueryReservedValue val) {
-        if (val == ServiceQueryReservedValue.EXISTS) {
-            mongoQuery.criteria(k).exists();
-        } else if (val == ServiceQueryReservedValue.NULL) {
-            mongoQuery.field(k).equal(null);
-        } else if (val == ServiceQueryReservedValue.ANY) {
-            // no op
-        } else {
-            throw new RestDslException("Unhandled reserved value: " + val, RestDslException.Type.GENERAL_ERROR);
-        }
-    }
-
-    @Override
-    public void validateQuery(ServiceQuery<K> serviceQuery) throws RestDslException {
-        if (serviceQuery.isIndexValidation()) {
-            boolean safeQuery = isSafeQuery(serviceQuery);
-            if (!safeQuery) {
-                throw new RestDslException("Query criterion for fields " + serviceQuery.getCriteria().keySet() +
-                        " don't match declared indexes  [(" + Joiner.on("), (").join(entityIndexInfo.getIndexesMap()) +
-                        ")] for class " + entityClazz.getName() +
-                        "; use '?indexValidation=false' query parameter to temporarily disable it for debugging purposes.",
-                        RestDslException.Type.QUERY_ERROR);
-            }
-        }
-
-        if (serviceQuery.getLimit() < 0) {
-            throw new RestDslException("Query limit must be positive", RestDslException.Type.QUERY_ERROR);
-        }
-
-        // for primary keys it could also works, but it does not make sense to group on them since they are unique
-        if (serviceQuery.getGroupBy() != null &&
-                (serviceQuery.getCriteria() == null || !serviceQuery.getCriteria().containsKey(serviceQuery.getGroupBy()))) {
-            throw new RestDslException("When provided, groupBy parameter should be contained in query criteria",
-                    RestDslException.Type.QUERY_ERROR);
-        }
-
-    }
-
-    @Override
-    public ServiceQueryInfo<K> getServiceQueryInfo(ServiceQuery<K> serviceQuery) {
-        return new ServiceQueryInfo<>(serviceQuery, isSafeQuery(serviceQuery));
-    }
-
-    private boolean isSafeQuery(ServiceQuery<K> serviceQuery) {
-        boolean queryIsSafe = true;
-        // criteria is not empty and primary keys are not specified, then we need to check whether index is used
-        boolean shouldCheckForIndex = serviceQuery.getCriteria() != null && !serviceQuery.getCriteria().isEmpty()
-                && CollectionUtils.isEmpty(serviceQuery.getIdList());
-
-        if (shouldCheckForIndex) {
-            queryIsSafe = false;
-            for (String field : serviceQuery.getCriteria().keySet()) {
-                if (entityIndexInfo.getIndexPrefixMap().contains(ServiceQueryUtil.parseQueryField(field).getFieldName())) {
-                    queryIsSafe = true;
-                    break;
-                }
-            }
-        }
-        return queryIsSafe;
-    }
-
     /**
-     * Use only when necessary.
+     * Use when you need to bypass restDsl, for example  internal operations
      *
      * @return morphia's dao
-     * @deprecated Use ServiceQuery when possible
+     * @deprecated Use {@link BaseMongoServiceDao#morphiaDao} instead, as it not unsafe to use morphia. This method will be removed soon because its public!
      */
     public BasicDAO<V, K> getMorphiaDaoUnsafe() {
         return morphiaDao;
@@ -424,11 +140,6 @@ public class MongoServiceDao<V, K> implements PersistentServiceDao<V, K> {
     @Override
     public void preDelete(ServiceQuery<K> q) {
         // no op
-    }
-
-    // PRIVATE
-    private StatsTimingWrapper getQueryShapeWrapper(ServiceQuery<K> serviceQuery) {
-        return StatsTimingWrapper.of(statsReporter, String.format(QUERY_KEY, collectionName + "." + serviceQuery.getQueryShape()));
     }
 
 }

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/PersistentServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/PersistentServiceDao.java
@@ -6,7 +6,7 @@ import net.researchgate.restdsl.queries.ServiceQuery;
 import java.util.Map;
 
 /**
- * DAO that also can instert, remove, patch entities
+ * DAO that also can insert, remove, patch entities
  */
 public interface PersistentServiceDao<V, K> extends ServiceDao<V, K>, EntityLifecycleListener<V, K> {
 

--- a/restler-core/src/main/java/net/researchgate/restdsl/model/BaseServiceModel.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/model/BaseServiceModel.java
@@ -1,0 +1,44 @@
+package net.researchgate.restdsl.model;
+
+import net.researchgate.restdsl.dao.ServiceDao;
+import net.researchgate.restdsl.exceptions.RestDslException;
+import net.researchgate.restdsl.queries.ServiceQuery;
+import net.researchgate.restdsl.queries.ServiceQueryInfo;
+import net.researchgate.restdsl.results.EntityResult;
+
+/**
+ * This model implements read only access to the underlying mongo collection.
+ * Use this model if you want to make sure that your data is only written to in a controlled way.
+ *
+ * If you want to simply expose CRUD via REST, use a {@link ServiceModel} instead.
+ *
+ * @param <V> Type of the entity
+ * @param <K> Type of the entity's id field
+ */
+public abstract class BaseServiceModel<V, K> {
+    protected ServiceDao<V, K> serviceDao;
+
+    public BaseServiceModel(ServiceDao<V, K> serviceDao) {
+        this.serviceDao = serviceDao;
+    }
+
+    protected ServiceDao<V, K> getServiceDao() {
+        return serviceDao;
+    }
+
+    public EntityResult<V> get(K id) throws RestDslException {
+        return serviceDao.get(ServiceQuery.byId(id));
+    }
+
+    public V getOne(K id) throws RestDslException {
+        return serviceDao.getOne(ServiceQuery.byId(id));
+    }
+
+    public EntityResult<V> get(ServiceQuery<K> q) throws RestDslException {
+        return serviceDao.get(q);
+    }
+
+    public ServiceQueryInfo<K> getServiceQueryInfo(ServiceQuery<K> q) {
+        return serviceDao.getServiceQueryInfo(q);
+    }
+}

--- a/restler-core/src/main/java/net/researchgate/restdsl/model/ServiceModel.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/model/ServiceModel.java
@@ -5,41 +5,30 @@ import net.researchgate.restdsl.domain.EntityInfo;
 import net.researchgate.restdsl.exceptions.RestDslException;
 import net.researchgate.restdsl.queries.PatchContext;
 import net.researchgate.restdsl.queries.ServiceQuery;
-import net.researchgate.restdsl.queries.ServiceQueryInfo;
-import net.researchgate.restdsl.results.EntityResult;
 import net.researchgate.restdsl.util.BeanUtils;
 
 import java.util.Collections;
 import java.util.Map;
 
 /**
- * General model
- * <p>
- * V - entity type
- * K - entity primary key type
+ * This model exposes full CRUD.
+ * Use this if you want simply want to expose the mongo operations via REST.
+ * If you have more challenging businessLogic, consider using {@link BaseServiceModel} and implement
+ * write operations yourself.
+ *
+ * @param <V> Type of the entity
+ * @param <K> Type of the entity's id field
  */
-public class ServiceModel<V, K> {
-    private PersistentServiceDao<V, K> serviceDao;
+public abstract class ServiceModel<V, K> extends BaseServiceModel<V, K> {
+    private final PersistentServiceDao<V, K> serviceDao;
 
     public ServiceModel(PersistentServiceDao<V, K> serviceDao) {
+        super(serviceDao);
         this.serviceDao = serviceDao;
     }
 
     protected PersistentServiceDao<V, K> getServiceDao() {
         return serviceDao;
-    }
-
-
-    public EntityResult<V> get(K id) throws RestDslException {
-        return serviceDao.get(ServiceQuery.byId(id));
-    }
-
-    public V getOne(K id) throws RestDslException {
-        return serviceDao.getOne(ServiceQuery.byId(id));
-    }
-
-    public EntityResult<V> get(ServiceQuery<K> q) throws RestDslException {
-        return serviceDao.get(q);
     }
 
     public int delete(ServiceQuery<K> q) throws RestDslException {
@@ -75,10 +64,6 @@ public class ServiceModel<V, K> {
             throw new RestDslException("Unable to diff the provided entity with the db entity (class " +
                     entity.getClass().getName() + ")", e, RestDslException.Type.ENTITY_ERROR);
         }
-    }
-
-    public ServiceQueryInfo<K> getServiceQueryInfo(ServiceQuery<K> q) {
-        return serviceDao.getServiceQueryInfo(q);
     }
 
 }

--- a/restler-core/src/main/java/net/researchgate/restdsl/resources/ServiceResource.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/resources/ServiceResource.java
@@ -27,9 +27,11 @@ import static javax.ws.rs.core.Response.Status.OK;
  * If you don't want all of these, extend BaseServiceResource yourself and include what you want.
  */
 public abstract class ServiceResource<V, K> extends BaseServiceResource<V, K> {
+    private final ServiceModel<V, K> serviceModel;
 
     public ServiceResource(ServiceModel<V, K> serviceModel, Class<V> entityClazz, Class<K> idClazz) {
         super(serviceModel, entityClazz, idClazz);
+        this.serviceModel = serviceModel;
     }
 
     @POST

--- a/restler-core/src/test/java/net/researchgate/restdsl/dao/ServiceDaoTest.java
+++ b/restler-core/src/test/java/net/researchgate/restdsl/dao/ServiceDaoTest.java
@@ -1,0 +1,78 @@
+package net.researchgate.restdsl.dao;
+
+import com.github.fakemongo.Fongo;
+import com.google.common.collect.Lists;
+import net.researchgate.restdsl.TestEntity;
+import net.researchgate.restdsl.exceptions.RestDslException;
+import net.researchgate.restdsl.metrics.NoOpStatsReporter;
+import net.researchgate.restdsl.metrics.StatsReporter;
+import net.researchgate.restdsl.queries.ServiceQuery;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Morphia;
+
+import static net.researchgate.restdsl.exceptions.RestDslException.Type.QUERY_ERROR;
+import static org.junit.Assert.fail;
+
+public class ServiceDaoTest {
+
+    // This merely allow us to spin up a a dao.
+    private Datastore fakedDatastore;
+
+    @Before
+    public void setUp() {
+        Fongo fongo = new Fongo("fake mongo");
+        fakedDatastore = new Morphia().createDatastore(fongo.getMongo(), "testDatabase");
+    }
+
+    @Test
+    public void testAllowGroupBy_doNotProvideAllowGroup_allow() {
+        final TestServiceDao dao = new TestServiceDao(fakedDatastore, TestEntity.class);
+
+        Assert.assertTrue(dao.allowGroupBy);
+        final ServiceQuery<Long> q = ServiceQuery.<Long>builder()
+                .withCriteria("id", Lists.newArrayList(1L, 2L, 3L))
+                .groupBy("id")
+                .build();
+        dao.get(q);
+    }
+
+    @Test
+    public void testAllowGroupBy_explicitlyDisallowGroupBy_doNotAllowQueryWithGroupBy() {
+        final TestServiceDao dao = new TestServiceDao(fakedDatastore, TestEntity.class, NoOpStatsReporter.INSTANCE, false);
+        Assert.assertFalse(dao.allowGroupBy);
+
+        final ServiceQuery<Long> q = ServiceQuery.<Long>builder()
+                .withCriteria("id", Lists.newArrayList(1L, 2L, 3L))
+                .groupBy("id")
+                .build();
+        // get with group by -> fail
+        try {
+            dao.get(q);
+            fail("Group by should not be allowed!, but it was");
+        } catch (RestDslException e) {
+            Assert.assertEquals(QUERY_ERROR, e.getType());
+        }
+
+        // get without groupBy -> successful
+        dao.get(ServiceQuery.byId(1L));
+
+        // explicitly allow group by -> successful
+        dao.setAllowGroupBy();
+        Assert.assertTrue(dao.allowGroupBy);
+        dao.get(q);
+    }
+
+    static class TestServiceDao extends MongoServiceDao<TestEntity, Long> {
+        public TestServiceDao(Datastore datastore, Class<TestEntity> entityClazz) {
+            super(datastore, entityClazz);
+        }
+
+        public TestServiceDao(Datastore datastore, Class<TestEntity> entityClazz, StatsReporter statsReporter, boolean allowGroupBy) {
+            super(datastore, entityClazz, statsReporter, allowGroupBy);
+        }
+    }
+
+}


### PR DESCRIPTION
This allows the service to gain more control over the data, by not exposing arbitrary writes to the client.

- Extracted BaseResource, BaseServiceModel and BaseServiceDao for when you want to implement updates yourself. 
- allow disabling of group by queries, to prevent very expensive queries. 
