### PR TITLE
Added delete by id per default to base* classes

### DIFF
--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseMongoServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseMongoServiceDao.java
@@ -130,14 +130,8 @@ public class BaseMongoServiceDao<V, K> implements ServiceDao<V, K>{
         return convertToMorphiaQuery(serviceQuery).count();
     }
 
-    /**
-     * Delete the entity by id value
-     * @param id the ID of the document to delete
-     * @return the number of deleted items (0 or 1)
-     */
     public int delete(K id) {
         return morphiaDao.deleteById(id).getN();
-
     }
 
     protected UpdateOperations<V> createUpdateOperations() {

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseMongoServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseMongoServiceDao.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * Use this dao if you want to make sure that your data is only written to in a controlled way.
  *
  * Supported operations
- * - get by restle dsl
+ * - get by restler dsl
  * - delete by id
  *
  * If you want to simply expose CRUD via REST, use a {@link MongoServiceDao}.

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseMongoServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseMongoServiceDao.java
@@ -36,8 +36,12 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * This Dao implements read only access to the underlying mongo collection.
+ * This Dao implements common access to the underlying mongo collection.
  * Use this dao if you want to make sure that your data is only written to in a controlled way.
+ *
+ * Supported operations
+ * - get by restle dsl
+ * - delete by id
  *
  * If you want to simply expose CRUD via REST, use a {@link MongoServiceDao}.
  *
@@ -124,6 +128,16 @@ public class BaseMongoServiceDao<V, K> implements ServiceDao<V, K>{
 
     public long count(ServiceQuery<K> serviceQuery) throws RestDslException {
         return convertToMorphiaQuery(serviceQuery).count();
+    }
+
+    /**
+     * Delete the entity by id value
+     * @param id the ID of the document to delete
+     * @return the number of deleted items (0 or 1)
+     */
+    public int delete(K id) {
+        return morphiaDao.deleteById(id).getN();
+
     }
 
     protected UpdateOperations<V> createUpdateOperations() {

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseServiceDao.java
@@ -5,7 +5,7 @@ package net.researchgate.restdsl.dao;
  * This dao describes the smallest common subset of operations for a dao that both reads and writes.
  * All other operations such as insert, overwrite, update, ... depend on the useCase.
  *
- * The PersistentServiceDao subinterface in contrast exposes all write operations.
+ * The PersistentServiceDao subInterface in contrast exposes all write operations.
  *
  *
  * @param <V>  value entity
@@ -16,7 +16,7 @@ public interface BaseServiceDao<V, K> extends ServiceDao<V, K> {
     /**
      * Delete the entity by its id
      *
-     * @param id the ID of the document to delete
+     * @param id the ID of the entity to delete
      * @return the number of deleted items (0 or 1)
      */
     int delete(K id);

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/BaseServiceDao.java
@@ -1,0 +1,24 @@
+package net.researchgate.restdsl.dao;
+
+/**
+ * A dao that also allows delete by id.
+ * This dao describes the smallest common subset of operations for a dao that both reads and writes.
+ * All other operations such as insert, overwrite, update, ... depend on the useCase.
+ *
+ * The PersistentServiceDao subinterface in contrast exposes all write operations.
+ *
+ *
+ * @param <V>  value entity
+ * @param <K> primary key of the value entity
+ */
+public interface BaseServiceDao<V, K> extends ServiceDao<V, K> {
+
+    /**
+     * Delete the entity by its id
+     *
+     * @param id the ID of the document to delete
+     * @return the number of deleted items (0 or 1)
+     */
+    int delete(K id);
+
+}

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/MongoBaseServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/MongoBaseServiceDao.java
@@ -48,8 +48,8 @@ import java.util.Set;
  * @param <V> Type of the entity
  * @param <K> Type of the entity's id field
  */
-public class BaseMongoServiceDao<V, K> implements ServiceDao<V, K>{
-    private static final Logger LOGGER = LoggerFactory.getLogger(BaseMongoServiceDao.class);
+public class MongoBaseServiceDao<V, K> implements BaseServiceDao<V, K>{
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoBaseServiceDao.class);
 
     private static final String QUERY_KEY = "queries.shapes.%s.%%H";
     protected final String collectionName;
@@ -62,11 +62,11 @@ public class BaseMongoServiceDao<V, K> implements ServiceDao<V, K>{
     // group by operations may require a lot requests to the database. We should have to explicitly enable it
     protected boolean allowGroupBy = false;
 
-    public BaseMongoServiceDao(Datastore datastore, Class<V> entityClazz) {
+    public MongoBaseServiceDao(Datastore datastore, Class<V> entityClazz) {
         this(datastore, entityClazz, NoOpStatsReporter.INSTANCE);
     }
     //TODO: provide implementations for StatsReporter in example service
-    public BaseMongoServiceDao(Datastore datastore, Class<V> entityClazz, StatsReporter statsReporter) {
+    public MongoBaseServiceDao(Datastore datastore, Class<V> entityClazz, StatsReporter statsReporter) {
         this.morphiaDao = new BasicDAO<>(entityClazz, datastore);
         this.collectionName = morphiaDao.getCollection().getName();
         this.entityClazz = entityClazz;

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/MongoServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/MongoServiceDao.java
@@ -20,14 +20,14 @@ import java.util.Map;
 /**
  * This dao exposes full CRUD.
  * Use this if you want simply want to expose the mongo operations via REST.
- * If you have more challenging businessLogic, consider using a {@link BaseMongoServiceDao} and implement
+ * If you have more challenging businessLogic, consider using a {@link MongoBaseServiceDao} and implement
  * write operations yourself.
  *
  * @param <V> Type of the entity
  * @param <K> Type of the entity's id field
  */
 @SuppressWarnings("WeakerAccess")
-public class MongoServiceDao<V, K> extends BaseMongoServiceDao<V, K> implements PersistentServiceDao<V, K> {
+public class MongoServiceDao<V, K> extends MongoBaseServiceDao<V, K> implements PersistentServiceDao<V, K> {
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoServiceDao.class);
 
     public MongoServiceDao(Datastore datastore, Class<V> entityClazz) {
@@ -121,7 +121,7 @@ public class MongoServiceDao<V, K> extends BaseMongoServiceDao<V, K> implements 
      * Use when you need to bypass restDsl, for example  internal operations
      *
      * @return morphia's dao
-     * @deprecated Use {@link BaseMongoServiceDao#morphiaDao} instead, as it not unsafe to use morphia. This method will be removed soon because its public!
+     * @deprecated Use {@link MongoBaseServiceDao#morphiaDao} instead, as it not unsafe to use morphia. This method will be removed soon because its public!
      */
     public BasicDAO<V, K> getMorphiaDaoUnsafe() {
         return morphiaDao;

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/PersistentServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/PersistentServiceDao.java
@@ -6,9 +6,14 @@ import net.researchgate.restdsl.queries.ServiceQuery;
 import java.util.Map;
 
 /**
- * DAO that also can insert, remove, patch entities
+ * DAO that also can insert, remove, patch entities.
+ * This should cover all the updateOperations.
+ * If you want to be more restrictive, consider using a smaller superInterface
+ *
+ *  @param <V>  value entity
+ *  @param <K> primary key of the value entity
  */
-public interface PersistentServiceDao<V, K> extends ServiceDao<V, K>, EntityLifecycleListener<V, K> {
+public interface PersistentServiceDao<V, K> extends BaseServiceDao<V, K>, EntityLifecycleListener<V, K> {
 
     /**
      * @param serviceQuery service query

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/ServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/ServiceDao.java
@@ -6,9 +6,9 @@ import net.researchgate.restdsl.queries.ServiceQueryInfo;
 import net.researchgate.restdsl.results.EntityResult;
 
 /**
- * Abstract representation of DAO. Can be Solr dao, or PG dao in theory
- * V - value entity
- * K - primary key of the value entity
+ * Abstract representation of a reading DAO. Can be Solr dao, or PG dao in theory
+ * @param <V> - value entity
+ * @param <K> - primary key of the value entity
  */
 public interface ServiceDao<V, K> {
 

--- a/restler-core/src/main/java/net/researchgate/restdsl/model/BaseServiceModel.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/model/BaseServiceModel.java
@@ -1,5 +1,6 @@
 package net.researchgate.restdsl.model;
 
+import net.researchgate.restdsl.dao.BaseServiceDao;
 import net.researchgate.restdsl.dao.ServiceDao;
 import net.researchgate.restdsl.exceptions.RestDslException;
 import net.researchgate.restdsl.queries.ServiceQuery;
@@ -7,8 +8,10 @@ import net.researchgate.restdsl.queries.ServiceQueryInfo;
 import net.researchgate.restdsl.results.EntityResult;
 
 /**
- * This model implements read only access to the underlying mongo collection.
+ * This model implements the smalles common subset of operations to the underlying mongo collection.
  * Use this model if you want to make sure that your data is only written to in a controlled way.
+ *
+ * @See ServiceModel if you want more supported operations
  *
  * If you want to simply expose CRUD via REST, use a {@link ServiceModel} instead.
  *
@@ -16,9 +19,9 @@ import net.researchgate.restdsl.results.EntityResult;
  * @param <K> Type of the entity's id field
  */
 public abstract class BaseServiceModel<V, K> {
-    protected ServiceDao<V, K> serviceDao;
+    protected BaseServiceDao<V, K> serviceDao;
 
-    public BaseServiceModel(ServiceDao<V, K> serviceDao) {
+    public BaseServiceModel(BaseServiceDao<V, K> serviceDao) {
         this.serviceDao = serviceDao;
     }
 
@@ -40,5 +43,15 @@ public abstract class BaseServiceModel<V, K> {
 
     public ServiceQueryInfo<K> getServiceQueryInfo(ServiceQuery<K> q) {
         return serviceDao.getServiceQueryInfo(q);
+    }
+
+    /**
+     * Delete the entity by its id
+     *
+     * @param id the ID of the entity to delete
+     * @return the number of deleted items (0 or 1)
+     */
+    public int delete(K id) {
+        return serviceDao.delete(id);
     }
 }

--- a/restler-core/src/main/java/net/researchgate/restdsl/model/BaseServiceModel.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/model/BaseServiceModel.java
@@ -11,8 +11,6 @@ import net.researchgate.restdsl.results.EntityResult;
  * This model implements the smalles common subset of operations to the underlying mongo collection.
  * Use this model if you want to make sure that your data is only written to in a controlled way.
  *
- * @See ServiceModel if you want more supported operations
- *
  * If you want to simply expose CRUD via REST, use a {@link ServiceModel} instead.
  *
  * @param <V> Type of the entity

--- a/restler-core/src/main/java/net/researchgate/restdsl/resources/BaseServiceResource.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/resources/BaseServiceResource.java
@@ -23,7 +23,7 @@ import java.lang.reflect.ParameterizedType;
  * Commons methods for CRUD. This base class includes only the HTTP GET verb. If you want the others too,
  * 1. Extend this class
  * 2. Override the corresponding method e.g. createEntity().
- * 3. Just call super.createEntity() in it, or custom logic.
+ * 3. Call super.createEntity() in it, or custom logic.
  * 4. Annotate the overridden method with e.g. @POST or @PATH(...) where applicable.
  * <p>
  * V - entity type
@@ -76,6 +76,26 @@ public abstract class BaseServiceResource<V, K> {
         ServiceQuery<K> query = getQueryFromRequest(segment, uriInfo);
         return serviceModel.getServiceQueryInfo(query);
     }
+
+// This method is intentionally commented out, in order to not to expose deletes to clients by default.
+// The following stub is a starting point to copyPaste into your subclass
+//
+//    /**
+//     * Delete the entity by its id.
+//     *
+//     * @return 200, if the entity was deleted, 404 otherwise
+//     */
+//    @Path("/{id}")
+//    @DELETE
+//    @Produces("application/json;charset=UTF-8")
+//    public Response delete(@PathParam("id") String idString) throws RestDslException {
+//        final K id = TypeInfoUtil.getValue(idString, null, idClazz, null);
+//        int deleted = serviceModel.delete(id);
+//        if (deleted == 0) {
+//            throw new NotFoundException();
+//        }
+//        return Response.ok().build();
+//    }
 
     protected K getId(String id) throws RestDslException {
         return TypeInfoUtil.getValue(id, EntityInfo.get(entityClazz).getIdFieldName(), idClazz, entityClazz);


### PR DESCRIPTION
at least internally, virtually all models\daos want to delete entries at some point. 

This PR adds delete to the (newly introduced and not usedyet) BaseModel and ao. 
The semantic change from 'readOnly'  to  'smallest reasonable api' . 
In contrast, the ServiceResource|Model|Dao exposes the 'widest possible api' 

