### PR TITLE
fix: Restored error handling for duplicate keys

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 6.0.1
+* Restored error handling for duplicate key exceptions
+
 ### 6.0.0
 * Backwards incompatible changes: 
   * Upgraded to mongodb-driver-sync 4.10.2 and morphia 2.4.4

--- a/restler-core/src/main/java/net/researchgate/restdsl/dao/MongoServiceDao.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/dao/MongoServiceDao.java
@@ -2,6 +2,11 @@ package net.researchgate.restdsl.dao;
 
 import com.google.common.collect.Lists;
 import com.mongodb.DuplicateKeyException;
+import com.mongodb.ErrorCategory;
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.MongoException;
+import com.mongodb.MongoWriteException;
+import com.mongodb.WriteError;
 import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.result.UpdateResult;
 import dev.morphia.Datastore;
@@ -69,8 +74,8 @@ public class MongoServiceDao<V, K> extends MongoBaseServiceDao<V, K> implements 
         prePersist(entity);
         try {
             datastore.save(entity);
-        } catch (DuplicateKeyException e) {
-            throw new RestDslException("Duplicate mongo key: " + e.getMessage(), RestDslException.Type.DUPLICATE_KEY);
+        } catch (DuplicateKeyException|MongoWriteException|MongoBulkWriteException e) {
+            throw mapMongoExceptions(e);
         }
         return entity;
     }
@@ -119,8 +124,20 @@ public class MongoServiceDao<V, K> extends MongoBaseServiceDao<V, K> implements 
 
         try {
             return morphiaQuery.modify(options, updateOperations.toArray(new UpdateOperator[0]));
-        } catch (DuplicateKeyException e) {
-            throw new RestDslException("Duplicate mongo key: " + e.getMessage(), RestDslException.Type.DUPLICATE_KEY);
+        } catch (DuplicateKeyException|MongoWriteException|MongoBulkWriteException e) {
+            throw mapMongoExceptions(e);
+        }
+    }
+
+    protected RuntimeException mapMongoExceptions(MongoException e) {
+        if (e instanceof DuplicateKeyException) {
+            return new RestDslException("Duplicate mongo key: " + e.getMessage(), RestDslException.Type.DUPLICATE_KEY);
+        } else if (e instanceof MongoWriteException && (ErrorCategory.DUPLICATE_KEY == ((MongoWriteException) e).getError().getCategory())) {
+            return new RestDslException("Duplicate mongo key: " + e.getMessage(), RestDslException.Type.DUPLICATE_KEY);
+        } else if (e instanceof MongoBulkWriteException && ((MongoBulkWriteException) e).getWriteErrors().stream().map(WriteError::getCategory).anyMatch(cat -> ErrorCategory.DUPLICATE_KEY == cat)) {
+            return new RestDslException("Duplicate mongo key: " + e.getMessage(), RestDslException.Type.DUPLICATE_KEY);
+        } else {
+            return new RuntimeException(e);
         }
     }
 

--- a/restler-core/src/test/java/net/researchgate/restdsl/dao/ServiceDaoTest.java
+++ b/restler-core/src/test/java/net/researchgate/restdsl/dao/ServiceDaoTest.java
@@ -5,6 +5,7 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+import com.mongodb.client.model.IndexOptions;
 import dev.morphia.Datastore;
 import dev.morphia.Morphia;
 import net.researchgate.restdsl.TestEntity;
@@ -12,6 +13,7 @@ import net.researchgate.restdsl.exceptions.RestDslException;
 import net.researchgate.restdsl.metrics.NoOpStatsReporter;
 import net.researchgate.restdsl.metrics.StatsReporter;
 import net.researchgate.restdsl.queries.ServiceQuery;
+import org.bson.Document;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -19,6 +21,7 @@ import org.junit.Test;
 import org.testcontainers.containers.GenericContainer;
 
 import static net.researchgate.restdsl.exceptions.RestDslException.Type.QUERY_ERROR;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class ServiceDaoTest {
@@ -33,9 +36,6 @@ public class ServiceDaoTest {
         mongoDBContainer.start();
 
         ConnectionString uri = new ConnectionString("mongodb://" + mongoDBContainer.getHost() + ":" + mongoDBContainer.getMappedPort(27017));
-        System.setProperty("dw.mongoConfig.uri", uri.toString());
-        System.setProperty("dw.mongoConfig.tls", "false");
-        System.setProperty("dw.mongoConfig.dbName", "testDatabase");
         MongoClientSettings clientSettings = MongoClientSettings.builder()
                 .applyConnectionString(uri)
                 .build();
@@ -93,6 +93,16 @@ public class ServiceDaoTest {
         dao.setAllowGroupBy();
         Assert.assertTrue(dao.allowGroupBy);
         dao.get(q);
+    }
+
+    @Test
+    public void testDuplicateKey_throws() {
+        fakedDatastore.getCollection(TestEntity.class)
+                .createIndex(new Document("value", 1), new IndexOptions().unique(true));
+        final TestServiceDao dao = new TestServiceDao(fakedDatastore, TestEntity.class);
+
+        dao.save(new TestEntity(2L, "nonUniqueValue"));
+        assertThrows(RestDslException.class, () -> dao.save(new TestEntity(3L, "nonUniqueValue")));
     }
 
     static class TestServiceDao extends MongoServiceDao<TestEntity, Long> {


### PR DESCRIPTION
Since new driver, error handling for duplicate keys changed:

* Original behaviour:
  * Duplicate keys were translated into RestDslException with type DUPLICATE_KEY
  * If restler's ServiceExceptionMapper was configured, resulting HTTP status was 409
  * With default ServiceExceptionMapper, resulting HTTP status was 500

* Current behaviour:
  * Duplicate keys were not detected due to driver not using the original exceptions
  * Resulting HTTP status is 500 regardless of configured exception mapper

The PR restores original behaviour.