### PR TITLE
feat(core) add @SegmentParameter annotation

### DIFF
--- a/restler-core/src/main/java/net/researchgate/restdsl/annotations/SegmentParameter.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/annotations/SegmentParameter.java
@@ -1,0 +1,26 @@
+package net.researchgate.restdsl.annotations;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(
+        name = "segment",
+        in = ParameterIn.PATH,
+        schema = @Schema(type = "string", example = "-"),
+        description = "A rest-dsl query, See https://github.com/researchgate/restler#get",
+        required = true
+)
+public @interface SegmentParameter {
+    String name() default "segment";
+    String description() default "A rest-dsl query, See https://github.com/researchgate/restler#get";
+    ParameterIn in() default ParameterIn.PATH;
+    boolean required() default true;
+}

--- a/restler-core/src/main/java/net/researchgate/restdsl/resources/BaseServiceResource.java
+++ b/restler-core/src/main/java/net/researchgate/restdsl/resources/BaseServiceResource.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
+import net.researchgate.restdsl.annotations.SegmentParameter;
 import net.researchgate.restdsl.domain.EntityInfo;
 import net.researchgate.restdsl.exceptions.RestDslException;
 import net.researchgate.restdsl.model.BaseServiceModel;
@@ -68,7 +69,7 @@ public abstract class BaseServiceResource<V, K> {
     }
 
     @Operation(summary = "Retrieve entities using the generic researchgate 'restler' query-language: https://github.com/researchgate/restler#get")
-    @Parameter(name = "segment", in = ParameterIn.PATH, schema = @Schema(type = "string", example = "-"), description = "A rest-dsl query, See https://github.com/researchgate/restler#get")
+    @SegmentParameter
     @Parameter(name = "fields", in = ParameterIn.QUERY, description = "Only return this list of comma-separated fields. Use '*' to return all", example = "*")
     @Parameter(name = "limit", in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int32"), description = "Limit the number of returned records")
     @Parameter(name = "offset", in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int32"), description = "Skip this many records. Use this together with limit to implement pagination.")
@@ -84,7 +85,7 @@ public abstract class BaseServiceResource<V, K> {
     }
 
     @Operation(summary = "Returns a human readable description of the generated database operations. This is intended for client to develop and debug rest-dsl queries")
-    @Parameter(name = "segment", in = ParameterIn.PATH, schema = @Schema(type = "string", example = "-"), description = "A rest-dsl query, See https://github.com/researchgate/restler#get")
+    @SegmentParameter
     @Parameter(name = "fields", in = ParameterIn.QUERY, description = "Only return this list of comma-separated fields. Use '*' to return all", example = "*")
     @Parameter(name = "limit", in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int32"), description = "Limit the number of returned records")
     @Parameter(name = "offset", in = ParameterIn.QUERY, schema = @Schema(type = "integer", format = "int32"), description = "Skip this many records. Use this together with limit to implement pagination.")


### PR DESCRIPTION
## This pull request

1. Creates a `@SegmentParameter` annotation, a meta-annotation that adopts default params for a restler segment param
2. Makes `BaseServiceResource` adopt the `@SegmentParamter` annotation

## The problem I'm trying to address

Services like refind use the `{segment}` path parameter often don't document them. This makes for a broken openapi specs that fails validation of some code generation tools.

This commit adds a `@SegmentParameter` annotation to make it easier for restler-core dependants to fix
their broken openapi specs.

## Next steps

This is less about the `restler-core` and more about our services. Upon approval of this merge request, I'll send out patches to another project (I'm mostly interested in refind atm) in order to help them fix this issue :)

## Where I need your help

I don't really know how to test this, and hopefully I don't need to know :innocent: Please have a look and let me know if you spot any problems with this.