### PR TITLE
chore: Updated Morphia to 2.4.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ project(":restler-core") {
     }
 
     dependencies {
-        compile group: 'dev.morphia.morphia', name: 'morphia-core', version: '2.4.15'
+        compile group: 'dev.morphia.morphia', name: 'morphia-core', version: '2.4.20'
         compile group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.10.2'
 
         compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.2'

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 6.1.5
+
+* Bump Morphia from 2.4.15 to 2.4.20 to incorporate performance improvements on point queries
+
 ### 6.1.4
 * Fix an issue with delete endpoint -> bulk deletes used to delete only one document.
 * Bumps test-container version to 1.21.4 for compatibility with newer docker runtimes.


### PR DESCRIPTION
Related: https://github.com/researchgate/commons-mongo/pull/13